### PR TITLE
Highlight code as an extension to the CommonMark Environment

### DIFF
--- a/src/Extensions/CodeHighlighterExtension.php
+++ b/src/Extensions/CodeHighlighterExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rias\MarkdownHighlight\Extensions;
+
+use League\CommonMark\Block\Element\FencedCode;
+use League\CommonMark\Block\Element\IndentedCode;
+use League\CommonMark\Block\Parser\FencedCodeParser;
+use League\CommonMark\ConfigurableEnvironmentInterface;
+use League\CommonMark\Extension\ExtensionInterface;
+use Spatie\CommonMarkHighlighter\FencedCodeRenderer;
+use Spatie\CommonMarkHighlighter\IndentedCodeRenderer;
+
+final class CodeHighlighterExtension implements ExtensionInterface
+{
+    public $autodetectLanguages;
+
+    public function __construct(?string $autodetectLanguages)
+    {
+        $this->autodetectLanguages = $autodetectLanguages ? explode(' ', $autodetectLanguages) : [];
+    }
+
+    public function register(ConfigurableEnvironmentInterface $environment)
+    {
+        $environment
+          ->addBlockRenderer(FencedCode::class, new FencedCodeRenderer($this->autodetectLanguages), 10)
+          ->addBlockRenderer(IndentedCode::class, new IndentedCodeRenderer($this->autodetectLanguages), 20);
+    }
+}

--- a/src/Fieldtypes/MarkdownHighlight.php
+++ b/src/Fieldtypes/MarkdownHighlight.php
@@ -14,14 +14,14 @@ class MarkdownHighlight extends MarkdownFieldtype
 
     protected function configFieldItems(): array
     {
-      return array_merge((new parent)->configFieldItems(), [
-          'autodetect_languages' => [
-              'display' => __('Auto-detect Languages'),
-              'instructions' => __('Space-separated list of languages to detect (leave empty to detect all)'),
-              'type' => 'text',
-              'width' => 100,
-          ],
-      ]);
+        return array_merge((new parent)->configFieldItems(), [
+            'autodetect_languages' => [
+                'display' => __('Auto-detect Languages'),
+                'instructions' => __('Space-separated list of languages to detect (leave empty to detect all)'),
+                'type' => 'text',
+                'width' => 100,
+            ],
+        ]);
     }
 
     public function augment($value)

--- a/src/Fieldtypes/MarkdownHighlight.php
+++ b/src/Fieldtypes/MarkdownHighlight.php
@@ -15,12 +15,12 @@ class MarkdownHighlight extends MarkdownFieldtype
     protected function configFieldItems(): array
     {
       return array_merge((new parent)->configFieldItems(), [
-        'autodetect_languages' => [
-            'display' => __('Auto-detect Languages'),
-            'instructions' => __('Space-separated list of languages to detect (leave empty to detect all)'),
-            'type' => 'text',
-            'width' => 100,
-        ],
+          'autodetect_languages' => [
+              'display' => __('Auto-detect Languages'),
+              'instructions' => __('Space-separated list of languages to detect (leave empty to detect all)'),
+              'type' => 'text',
+              'width' => 100,
+          ],
       ]);
     }
 

--- a/src/Fieldtypes/MarkdownHighlight.php
+++ b/src/Fieldtypes/MarkdownHighlight.php
@@ -2,38 +2,61 @@
 
 namespace Rias\MarkdownHighlight\Fieldtypes;
 
-use League\CommonMark\Block\Element\FencedCode;
-use League\CommonMark\Block\Element\IndentedCode;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use Spatie\CommonMarkHighlighter\FencedCodeRenderer;
-use Spatie\CommonMarkHighlighter\IndentedCodeRenderer;
-use Statamic\Fieldtypes\Markdown;
+use Statamic\Fieldtypes\Markdown as MarkdownFieldtype;
+use Statamic\Facades\Markdown as MarkdownManager;
+use Rias\MarkdownHighlight\Extensions\CodeHighlighterExtension;
 
-class MarkdownHighlight extends Markdown
+class MarkdownHighlight extends MarkdownFieldtype
 {
     protected $icon = 'code-block';
+    protected $component = 'markdown';
+    protected $indexComponent = 'markdown';
 
-    protected $configFields = [];
+    protected function configFieldItems(): array
+    {
+      return array_merge((new parent)->configFieldItems(), [
+        'autodetect_languages' => [
+            'display' => __('Auto-detect Languages'),
+            'instructions' => __('Space-separated list of languages to detect (leave empty to detect all)'),
+            'type' => 'text',
+            'width' => 100,
+        ],
+      ]);
+    }
 
     public function augment($value)
     {
-        $environment = Environment::createCommonMarkEnvironment()
-            ->addBlockRenderer(FencedCode::class, new FencedCodeRenderer())
-            ->addBlockRenderer(IndentedCode::class, new IndentedCodeRenderer());
+        if (is_null($value)) {
+            return;
+        }
 
-        $commonMarkConverter = new CommonMarkConverter([], $environment);
+        /** @var \Statamic\Markdown\Parser */
+        $parser = MarkdownManager::parser(
+            $this->config('parser', 'default')
+        );
 
-        return $commonMarkConverter->convertToHtml($value);
-    }
+        $parser = $parser->newInstance()->addExtension(function () {
+            return new CodeHighlighterExtension(
+               $this->config('autodetect_languages')
+            );
+        });
 
-    public function component(): string
-    {
-        return 'markdown';
-    }
+        if ($this->config('automatic_line_breaks')) {
+            $parser = $parser->withAutoLineBreaks();
+        }
 
-    public function indexComponent(): string
-    {
-        return 'markdown';
+        if ($this->config('escape_markup')) {
+            $parser = $parser->withMarkupEscaping();
+        }
+
+        if ($this->config('automatic_links')) {
+            $parser = $parser->withAutoLinks();
+        }
+
+        if ($this->config('smartypants')) {
+            $parser = $parser->withSmartPunctuation();
+        }
+
+        return $parser->parse((string) $value);
     }
 }

--- a/src/Fieldtypes/MarkdownHighlight.php
+++ b/src/Fieldtypes/MarkdownHighlight.php
@@ -37,7 +37,7 @@ class MarkdownHighlight extends MarkdownFieldtype
 
         $parser = $parser->newInstance()->addExtension(function () {
             return new CodeHighlighterExtension(
-               $this->config('autodetect_languages')
+                $this->config('autodetect_languages')
             );
         });
 


### PR DESCRIPTION
The current MarkdownHighlight field type creates a new evironment and registers renderers for code highlighting. However, it extends the core Markdown fieldtype, which exposes configuration that is never used, such as smart punctuation, auto-linking, custom parsers, etc.

This PR changes the way code highlighting is done, by registering an extension that introduces the behaviour additively.

Additionally, it adds a new configuration item that allows for a space-separated list of auto-detectable languages to be specified, as recommended here: https://github.com/spatie/commonmark-highlighter#usage

I have tested this on my personal website (locally), but would appreciate a second pair of eyes to verify that it works correctly.

Thanks! 